### PR TITLE
Add ValueCommerce agent and Claude Code pre-commit hook

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,59 @@
+# Claude Code Hooks
+
+This directory contains hooks for automating Claude Code workflows.
+
+## Pre-Commit Check Hook
+
+The `UserPromptSubmit` hook intercepts commit-related prompts and adds a reminder to check for unused code.
+
+### Setup
+
+Add this to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "./.claude/hooks/pre-commit-check.sh"
+      }]
+    }]
+  }
+}
+```
+
+### What it does
+
+When you ask Claude to commit changes, the hook:
+1. Detects commit-related prompts (contains "commit" or "staged")
+2. Reminds you to check for:
+   - Unused dependencies
+   - Empty files
+   - Unused imports/exports
+   - Dead code
+3. Adds context about keeping codebase minimal
+
+### How to use
+
+Just commit normally through Claude Code:
+```
+"commit the changes"
+"check staged changes and commit"
+```
+
+Claude will automatically remind you to verify the code is minimal before committing.
+
+### Override
+
+To skip the check, use `--no-verify` in your prompt:
+```
+"commit --no-verify"
+```
+
+## Files
+
+- `README.md` - This file
+- `pre-commit-check.sh` - Script that validates staged changes
+- Example configuration in project `.claude/settings.json`

--- a/.claude/hooks/pre-commit-check.sh
+++ b/.claude/hooks/pre-commit-check.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Claude Code UserPromptSubmit Hook - Pre-Commit Check
+#
+# This hook runs when user submits a prompt to Claude Code.
+# It detects commit-related prompts and adds a reminder to check for unused code.
+#
+# Input: JSON via stdin with prompt and conversation history
+# Output: JSON with additionalContext or block decision
+#
+
+# Read stdin (JSON input from Claude Code)
+INPUT=$(cat)
+
+# Extract the user's prompt from JSON
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // empty')
+
+# Check if prompt is about committing
+if echo "$PROMPT" | grep -qi -E "(commit|staged|git add)"; then
+    # Check if --no-verify flag is present
+    if echo "$PROMPT" | grep -qi "\-\-no-verify"; then
+        # User explicitly wants to skip verification
+        echo '{}'
+        exit 0
+    fi
+
+    # Get staged files count
+    STAGED_COUNT=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$STAGED_COUNT" -gt 0 ]; then
+        # Add context reminder to check for minimal codebase
+        CONTEXT="
+
+⚠️ Pre-commit reminder: Check staged changes for minimal codebase
+- Remove unused dependencies (package.json)
+- Remove empty files or unused code
+- Remove unused imports/exports
+- Verify all changes are necessary
+
+Staged files: $STAGED_COUNT
+
+To skip this check, add '--no-verify' to your prompt.
+"
+
+        # Output JSON with additionalContext
+        jq -n \
+            --arg context "$CONTEXT" \
+            '{hookSpecificOutput: {additionalContext: $context}}'
+        exit 0
+    fi
+fi
+
+# No modification needed
+echo '{}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/pre-commit-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # private
 .private
+
+# claude code local settings
+.claude/settings.local.json

--- a/scripts/valuecommerce-agent/README.md
+++ b/scripts/valuecommerce-agent/README.md
@@ -1,0 +1,46 @@
+# ValueCommerce Agent
+
+Automates ValueCommerce MyLinkBox creation for hub.momit.fm articles via Claude Code.
+
+## Usage
+
+Ask Claude Code:
+```
+Check https://hub.momit.fm/post-XXX/ and create a ValueCommerce MyLinkBox if needed
+```
+
+Claude will:
+1. Navigate to the article and check if it has VC links
+2. Extract product information from the article
+3. Open ValueCommerce login (you login manually)
+4. Guide you through MyLinkBox creation step-by-step
+
+**Why this approach?** No passwords stored, works with 2FA, secure manual login.
+
+## How It Works
+
+Claude Code uses Playwright MCP to:
+1. Check article for existing MyLinkBox widgets
+2. Extract product names from Amazon links in the article
+3. Open ValueCommerce login page (you login manually)
+4. Fill MyLinkBox creation form with product info
+5. Guide you through product selection and submission
+
+## Important Notes
+
+### Form Field Rules
+When creating MyLinkBox, fill fields as follows:
+- **MyLinkBox名**: `{category}_{product}` (e.g., "海外渡航グッズ_パスポートカバー")
+- **キーワード**: Exact product name from article (e.g., "スーパーマリオ パスポートカバー")
+- **タイトル**: **SAME as キーワード** (must be identical!)
+
+### Product Extraction
+- Agent extracts specific product names from Amazon/affiliate links in article
+- Use product name (not article title) for search keyword
+- Example: Article about UM travel → Product: "スーパーマリオ パスポートカバー（マリオキャラクターズ）"
+
+### Technical Details
+- Requires Claude Code with Playwright MCP
+- Uses manual login (no credentials stored)
+- Screenshots saved to ~/Downloads/ for reference
+- Browser stays open until user completes manual steps

--- a/scripts/valuecommerce-agent/agent-mcp.js
+++ b/scripts/valuecommerce-agent/agent-mcp.js
@@ -1,0 +1,40 @@
+/**
+ * ValueCommerce Affiliate Agent (MCP Version)
+ *
+ * INSTRUCTIONS FOR CLAUDE CODE:
+ *
+ * When user asks to "Check <article-url> and create a ValueCommerce MyLinkBox if needed":
+ *
+ * 1. Check the article for ValueCommerce links
+ *    - Navigate to article URL using mcp__playwright-mcp__playwright_navigate
+ *    - Use mcp__playwright-mcp__playwright_evaluate to check:
+ *      - ValueCommerce iframes: iframe[src*="valuecommerce"]
+ *      - MyLinkBox divs: [data-vc_mylinkbox_id]
+ *    - Extract article title from h1.entry-title
+ *    - Extract product names from Amazon links
+ *
+ * 2. If article already has MyLinkBox widgets:
+ *    - Report to user and close browser
+ *
+ * 3. If article is missing MyLinkBox:
+ *    - Navigate to https://aff.valuecommerce.ne.jp/
+ *    - Take screenshot and ask user to login manually
+ *    - Wait for user confirmation
+ *
+ * 4. Navigate to MyLinkBox creation page:
+ *    - Go to https://aff.valuecommerce.ne.jp/ad/myLinkBox/create
+ *
+ * 5. Fill the MyLinkBox form:
+ *    - MyLinkBox名: "{category}_{product}" (e.g., "スマートリング_OuraRing")
+ *    - キーワード: Exact product name from article
+ *    - タイトル: SAME as キーワード (must be identical!)
+ *
+ * 6. Guide user to complete:
+ *    - Search for products
+ *    - Select matching products
+ *    - Choose design/layout
+ *    - Submit form
+ *
+ * 7. Close browser when done
+ *    - Use mcp__playwright-mcp__playwright_close
+ */


### PR DESCRIPTION
## Summary
- Add minimal ValueCommerce MyLinkBox agent via Playwright MCP
- Add Claude Code pre-commit hook to maintain minimal codebase

## ValueCommerce Agent
**Usage**: Ask Claude Code to check article and create MyLinkBox
```
Check https://hub.momit.fm/post-XXX/ and create a ValueCommerce MyLinkBox if needed
```

**Features**:
- Uses Playwright MCP with manual login (no credentials stored)
- Checks article for existing MyLinkBox widgets
- Extracts product info from Amazon links
- Guides MyLinkBox creation interactively
- Minimal: Just 2 files, no dependencies (93 lines total)

**Files**:
- `scripts/valuecommerce-agent/agent-mcp.js` - Claude Code workflow instructions
- `scripts/valuecommerce-agent/README.md` - Usage guide

## Claude Code Pre-Commit Hook
**Purpose**: Automatically reminds to check for unused code before committing

**Features**:
- Triggers on commit-related prompts
- Checks staged files count
- Reminds to remove: unused dependencies, empty files, unused imports, dead code
- Can be skipped with `--no-verify`

**Files**:
- `.claude/settings.json` - Hook configuration (team-shared)
- `.claude/hooks/pre-commit-check.sh` - Hook script
- `.claude/hooks/README.md` - Documentation

## Changes
- 7 files changed, 291 insertions, 3 deletions
- No new dependencies
- All code is minimal and documented
- Follows codebase simplicity guidelines

## Test Plan
- [x] ValueCommerce agent tested on hub.momit.fm/post-628/
- [x] Pre-commit hook tested with staged changes
- [x] Hook correctly detects commit prompts
- [x] Hook adds reminder context to Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Playwright MCP ValueCommerce MyLinkBox agent and a Claude Code pre-commit reminder hook, plus docs and .gitignore updates.
> 
> - **Automation**:
>   - **ValueCommerce agent**: Add `scripts/valuecommerce-agent/agent-mcp.js` (MCP workflow for MyLinkBox creation with manual login) and `scripts/valuecommerce-agent/README.md` (usage and rules).
> - **Claude Code Hooks**:
>   - Add pre-commit reminder hook via `./.claude/hooks/pre-commit-check.sh` and configure in `.claude/settings.json` to inject minimal-code checks on commit prompts (skippable with `--no-verify`).
>   - Document hook usage in `.claude/hooks/README.md`.
> - **Docs**:
>   - Expand `CLAUDE.md` with app commands, transcript processing, ValueCommerce agent workflow, and GitHub Actions overview.
> - **Config**:
>   - Update `.gitignore` to ignore `.env` and `.claude/settings.local.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 209491b180d48f262ed97a56acf8d7d5b1fa7091. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->