### PR TITLE
Add transcript intake automation and agent docs

### DIFF
--- a/.claude/hooks/check-riverside-downloads.sh
+++ b/.claude/hooks/check-riverside-downloads.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SessionStart hook: detect recent unrenamed Riverside exports in ~/Downloads
+# and surface a notification so the assistant prompts the user to release.
+# Stays silent (exit 0, no output) when nothing relevant is found.
+
+set -u
+
+DOWNLOADS_DIR="$HOME/Downloads"
+RECENCY_DAYS=7
+RSS_URL="https://rss.art19.com/momitfm"
+
+[ -d "$DOWNLOADS_DIR" ] || exit 0
+
+# Newest unrenamed file for a given extension within the recency window, or empty.
+# Mirrors scripts/renameDownloads.js findCandidateFiles() behavior.
+newest_with_ext() {
+  local ext="$1"
+  local newest_time=0
+  local newest_file=""
+  local f t
+  while IFS= read -r -d '' f; do
+    t=$(stat -f '%m' "$f" 2>/dev/null) || continue
+    if [ "$t" -gt "$newest_time" ]; then
+      newest_time=$t
+      newest_file="$f"
+    fi
+  done < <(find "$DOWNLOADS_DIR" -maxdepth 1 -type f \
+    -iname "*.${ext}" \
+    ! -iname 'momitfm*' \
+    -mtime -"${RECENCY_DAYS}" \
+    -print0 2>/dev/null)
+  printf '%s' "$newest_file"
+}
+
+txt=$(newest_with_ext txt)
+srt=$(newest_with_ext srt)
+mp3=$(newest_with_ext mp3)
+
+if [ -z "${txt}${srt}${mp3}" ]; then
+  exit 0
+fi
+
+# Best-effort: derive next episode number from RSS (items + 1, same as renameDownloads.js)
+ep_num=""
+if command -v curl >/dev/null 2>&1; then
+  rss=$(curl -fsS --max-time 5 "$RSS_URL" 2>/dev/null || true)
+  if [ -n "$rss" ]; then
+    item_count=$(printf '%s' "$rss" | grep -c '<item>' || true)
+    if [ "${item_count:-0}" -gt 0 ]; then
+      ep_num=$((item_count + 1))
+    fi
+  fi
+fi
+
+format_line() {
+  local f="$1"
+  [ -z "$f" ] && return 0
+  local name date
+  name=$(basename "$f")
+  date=$(stat -f '%Sm' -t '%-m/%-d' "$f" 2>/dev/null)
+  printf '  - %s (%s)\n' "$name" "$date"
+}
+
+if [ -n "$ep_num" ]; then
+  echo "📻 New Riverside materials detected in ~/Downloads for episode ${ep_num}:"
+else
+  echo "📻 New Riverside materials detected in ~/Downloads:"
+fi
+format_line "$txt"
+format_line "$srt"
+format_line "$mp3"
+echo
+if [ -n "$ep_num" ]; then
+  echo "To release this episode, run: /release-episode ${ep_num}"
+else
+  echo "To release this episode, run: /release-episode <N>  (RSS lookup failed; verify episode number)"
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,5 @@
-# Repository Guidelines
+# Repository Guidelines for AI Agents
 
-## Project Structure & Module Organization
-- `pages/` holds Next.js routes (`index.tsx`, `episode/[id].tsx` for episode pages).
-- `components/` contains shared UI (Header, Footer, Head).
-- `styles/` uses CSS Modules (e.g., `styles/Home.module.css`).
-- `const/` and `util/` hold site constants and helpers.
-- `public/` contains static assets and transcripts at `public/transcripts/{episodeId}.json`.
-- `scripts/` includes automation like `convertTranscript.js` and the ValueCommerce agent.
+This repository's agent guidelines live in [`CLAUDE.md`](./CLAUDE.md) — please read that file first.
 
-## Build, Test, and Development Commands
-- `npm run dev` starts the dev server at `http://localhost:3000`.
-- `npm run build` creates a production build.
-- `npm start` runs the production server.
-- `npm run lint` runs ESLint (Next.js config).
-- `node scripts/convertTranscript.js <episode-number>` converts `~/Downloads/momitfm{N}.txt` to `public/transcripts/{N}.json`.
-
-## Coding Style & Naming Conventions
-- TypeScript + React (Next.js). Keep imports ordered and lean.
-- Indentation is 2 spaces (match existing files like `pages/index.tsx`).
-- CSS Modules naming is `styles.<token>`; keep class names descriptive.
-- Use `strict: false` TypeScript patterns; avoid introducing stricter types without a reason.
-- Lint with `npm run lint` before PRs.
-
-## Testing Guidelines
-- No dedicated test folder/framework is currently configured.
-- If you add tests (e.g., Playwright), place them under `tests/` and document the command in this file.
-- Manual check: run `npm run dev` and validate homepage + an episode page.
-
-## Commit & Pull Request Guidelines
-- Commit messages are short, imperative, and task-focused (e.g., “Add transcript for episode 92”, “Update RSS hash”).
-- PRs should include: a brief summary, what changed, and screenshots for UI updates.
-- Link related issues or episodes when applicable.
-
-## Automation & Configuration Notes
-- RSS-driven content is fetched at build time (see `const/` + RSS logic in `pages/`).
-- GitHub Actions update the RSS hash and generate announcements.
-
-## Agent-Specific Instructions
-- Keep docs consolidated; prefer updating existing docs over adding new ones.
-- Remove obvious dead code or unused imports when touching files.
+The conventions there (project structure, build commands, coding style, commit/PR rules, automation notes) apply to all AI agents working in this repo, not just Claude.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `pages/` holds Next.js routes (`index.tsx`, `episode/[id].tsx` for episode pages).
+- `components/` contains shared UI (Header, Footer, Head).
+- `styles/` uses CSS Modules (e.g., `styles/Home.module.css`).
+- `const/` and `util/` hold site constants and helpers.
+- `public/` contains static assets and transcripts at `public/transcripts/{episodeId}.json`.
+- `scripts/` includes automation like `convertTranscript.js` and the ValueCommerce agent.
+
+## Build, Test, and Development Commands
+- `npm run dev` starts the dev server at `http://localhost:3000`.
+- `npm run build` creates a production build.
+- `npm start` runs the production server.
+- `npm run lint` runs ESLint (Next.js config).
+- `node scripts/convertTranscript.js <episode-number>` converts `~/Downloads/momitfm{N}.txt` to `public/transcripts/{N}.json`.
+
+## Coding Style & Naming Conventions
+- TypeScript + React (Next.js). Keep imports ordered and lean.
+- Indentation is 2 spaces (match existing files like `pages/index.tsx`).
+- CSS Modules naming is `styles.<token>`; keep class names descriptive.
+- Use `strict: false` TypeScript patterns; avoid introducing stricter types without a reason.
+- Lint with `npm run lint` before PRs.
+
+## Testing Guidelines
+- No dedicated test folder/framework is currently configured.
+- If you add tests (e.g., Playwright), place them under `tests/` and document the command in this file.
+- Manual check: run `npm run dev` and validate homepage + an episode page.
+
+## Commit & Pull Request Guidelines
+- Commit messages are short, imperative, and task-focused (e.g., “Add transcript for episode 92”, “Update RSS hash”).
+- PRs should include: a brief summary, what changed, and screenshots for UI updates.
+- Link related issues or episodes when applicable.
+
+## Automation & Configuration Notes
+- RSS-driven content is fetched at build time (see `const/` + RSS logic in `pages/`).
+- GitHub Actions update the RSS hash and generate announcements.
+
+## Agent-Specific Instructions
+- Keep docs consolidated; prefer updating existing docs over adding new ones.
+- Remove obvious dead code or unused imports when touching files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,11 @@ Episodes contain:
 
 ## Scripts and Automation
 
+### Download Renaming (scripts/renameDownloads.js)
+- `node scripts/renameDownloads.js [episode-number]` - Rename Riverside downloads (txt/srt/mp3) to momitfm{N} convention
+- Auto-detects next episode number from RSS feed if not specified
+- Finds the most recently modified files in ~/Downloads (past 7 days, excludes already-renamed momitfm* files)
+
 ### Transcript Processing (scripts/convertTranscript.js)
 Converts raw transcript text files into structured JSON format for episodes.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "validate-transcript": "node scripts/validateTranscript.js"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/scripts/convertTranscript.js
+++ b/scripts/convertTranscript.js
@@ -1,93 +1,49 @@
 const fs = require('fs');
 const path = require('path');
+const { parseTranscriptText } = require('./transcriptUtils');
 
-function parseTranscriptText(text, episodeId) {
-  const lines = text.split('\n');
-  const segments = [];
+function parseCliArgs(argv) {
+  const args = {
+    episodeNum: null,
+    inputPath: null,
+    outputPath: null
+  };
 
-  let currentSpeaker = '';
-  let currentTimestamp = '';
-  let currentText = '';
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-
-    // Match speaker and timestamp pattern: "Speaker Name (00:00.000)" or "Speaker Name (00:00.00)"
-    const speakerMatch = trimmed.match(/^(.+?)\s*\((\d{1,2}:\d{2}\.\d{2,3})\)$/);
-
-    if (speakerMatch) {
-      // Save previous segment if exists
-      if (currentSpeaker && currentText) {
-        segments.push({
-          speaker: currentSpeaker,
-          timestamp: formatTimestamp(currentTimestamp),
-          text: currentText.trim()
-        });
-      }
-
-      // Start new segment
-      currentSpeaker = speakerMatch[1];
-      currentTimestamp = speakerMatch[2];
-      currentText = '';
-    } else {
-      // Continuation of current speaker's text
-      // Remove spaces between Japanese characters
-      const cleanedText = trimmed.replace(/\s+/g, '');
-      currentText += (currentText ? '' : '') + cleanedText;
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--input') {
+      args.inputPath = argv[i + 1];
+      i += 1;
+    } else if (arg === '--output') {
+      args.outputPath = argv[i + 1];
+      i += 1;
+    } else if (!args.episodeNum) {
+      args.episodeNum = parseInt(arg, 10);
     }
   }
 
-  // Add last segment
-  if (currentSpeaker && currentText) {
-    segments.push({
-      speaker: currentSpeaker,
-      timestamp: formatTimestamp(currentTimestamp),
-      text: currentText.trim()
-    });
-  }
-
-  return {
-    episodeId,
-    segments
-  };
+  return args;
 }
 
-function formatTimestamp(timestamp) {
-  // Convert MM:SS.mmm to HH:MM:SS format
-  const [minSec] = timestamp.split('.');
-  const parts = minSec.split(':');
+const { episodeNum, inputPath, outputPath } = parseCliArgs(process.argv);
 
-  if (parts.length === 2) {
-    const [min, sec] = parts;
-    return `00:${min.padStart(2, '0')}:${sec.padStart(2, '0')}`;
-  } else if (parts.length === 3) {
-    return timestamp; // Already in HH:MM:SS format
-  }
-
-  return timestamp;
-}
-
-// Get episode number from command line argument or process all available
-const episodeArg = process.argv[2];
-
-if (episodeArg) {
+if (episodeNum) {
   // Process single episode
-  const episodeNum = parseInt(episodeArg);
-  const transcriptPath = path.join(process.env.HOME, 'Downloads', `momitfm${episodeNum}.txt`);
-  const outputPath = path.join(process.cwd(), 'public', 'transcripts', `${episodeNum}.json`);
+  const transcriptPath = inputPath || path.join(process.env.HOME, 'Downloads', `momitfm${episodeNum}.txt`);
+  const resolvedOutputPath = outputPath || path.join(process.cwd(), 'public', 'transcripts', `${episodeNum}.json`);
 
   try {
     const text = fs.readFileSync(transcriptPath, 'utf-8');
     const transcript = parseTranscriptText(text, episodeNum);
 
-    fs.writeFileSync(outputPath, JSON.stringify(transcript, null, 2), 'utf-8');
+    fs.writeFileSync(resolvedOutputPath, JSON.stringify(transcript, null, 2), 'utf-8');
     console.log(`✅ Episode ${episodeNum} transcript converted successfully!`);
     console.log(`   Input: ${transcriptPath}`);
-    console.log(`   Output: ${outputPath}`);
+    console.log(`   Output: ${resolvedOutputPath}`);
     console.log(`   Total segments: ${transcript.segments.length}`);
   } catch (error) {
     console.error(`Error converting episode ${episodeNum}:`, error.message);
+    process.exitCode = 1;
   }
 } else {
   // Process all available episodes
@@ -108,6 +64,7 @@ if (episodeArg) {
       }
     } catch (error) {
       console.error(`Error converting episode ${episodeNum}:`, error.message);
+      process.exitCode = 1;
     }
   });
 }

--- a/scripts/renameDownloads.js
+++ b/scripts/renameDownloads.js
@@ -1,0 +1,170 @@
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const readline = require('readline');
+const xml2js = require('xml2js');
+
+const RSS_URL = 'https://rss.art19.com/momitfm';
+const DOWNLOADS_DIR = path.join(process.env.HOME, 'Downloads');
+const EXTENSIONS = ['.txt', '.srt', '.mp3'];
+const RECENCY_DAYS = 7;
+
+function parseArgs(argv) {
+  const args = {
+    episodeNum: null,
+    autoApprove: false,
+    json: false
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--yes') {
+      args.autoApprove = true;
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (!args.episodeNum) {
+      args.episodeNum = parseInt(arg, 10);
+    }
+  }
+
+  return args;
+}
+
+function fetchNextEpisodeNumber() {
+  return new Promise((resolve, reject) => {
+    https.get(RSS_URL, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        const parser = new xml2js.Parser();
+        parser.parseString(data, (err, result) => {
+          if (err) return reject(err);
+          const items = result.rss.channel[0].item;
+          resolve(items.length + 1);
+        });
+      });
+    }).on('error', reject);
+  });
+}
+
+function findCandidateFiles() {
+  const cutoff = Date.now() - RECENCY_DAYS * 24 * 60 * 60 * 1000;
+  const allFiles = fs.readdirSync(DOWNLOADS_DIR);
+  const candidates = new Map();
+
+  for (const ext of EXTENSIONS) {
+    const matching = allFiles
+      .filter((f) => {
+        if (!f.endsWith(ext)) return false;
+        if (f.startsWith('momitfm')) return false;
+        const stat = fs.statSync(path.join(DOWNLOADS_DIR, f));
+        return stat.isFile() && stat.mtimeMs >= cutoff;
+      })
+      .map((f) => {
+        const stat = fs.statSync(path.join(DOWNLOADS_DIR, f));
+        return { name: f, mtime: stat.mtimeMs };
+      })
+      .sort((a, b) => b.mtime - a.mtime);
+
+    if (matching.length > 0) {
+      candidates.set(ext, matching[0].name);
+    }
+  }
+
+  return candidates;
+}
+
+function askConfirmation(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y');
+    });
+  });
+}
+
+async function main() {
+  // 1. Determine episode number
+  let episodeNum;
+  const args = parseArgs(process.argv);
+  if (args.episodeNum) {
+    episodeNum = args.episodeNum;
+    if (isNaN(episodeNum)) {
+      console.error('エピソード番号が不正です:', process.argv[2]);
+      process.exit(1);
+    }
+  } else {
+    try {
+      episodeNum = await fetchNextEpisodeNumber();
+      console.log(`RSS から次のエピソード番号を取得: ${episodeNum}`);
+    } catch (err) {
+      console.error('RSS フィードの取得に失敗しました:', err.message);
+      console.error('手動でエピソード番号を指定してください: node scripts/renameDownloads.js <episode-number>');
+      process.exit(1);
+    }
+  }
+
+  // 2. Find candidate files
+  const candidates = findCandidateFiles();
+  if (candidates.size === 0) {
+    console.log(`~/Downloads に過去 ${RECENCY_DAYS} 日以内の対象ファイル (.txt, .srt, .mp3) が見つかりませんでした。`);
+    process.exit(0);
+  }
+
+  // 3. Build rename plan and check for conflicts
+  const renames = [];
+  for (const [ext, fileName] of candidates) {
+    const target = `momitfm${episodeNum}${ext}`;
+    const targetPath = path.join(DOWNLOADS_DIR, target);
+    if (fs.existsSync(targetPath)) {
+      console.log(`⚠️  スキップ: ${target} は既に存在します`);
+      continue;
+    }
+    renames.push({
+      from: path.join(DOWNLOADS_DIR, fileName),
+      to: targetPath,
+      fromName: fileName,
+      toName: target,
+    });
+  }
+
+  if (renames.length === 0) {
+    console.log('リネーム対象のファイルがありません。');
+    process.exit(0);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({
+      episodeNum,
+      renames
+    }, null, 2));
+    if (!args.autoApprove) {
+      process.exit(0);
+    }
+  }
+
+  // 4. Show plan and confirm
+  console.log(`\nEpisode ${episodeNum} のファイルをリネームします:\n`);
+  const maxFromLen = Math.max(...renames.map((r) => r.fromName.length));
+  for (const r of renames) {
+    console.log(`  ${r.fromName.padEnd(maxFromLen)}  ->  ${r.toName}`);
+  }
+  console.log();
+
+  const confirmed = args.autoApprove ? true : await askConfirmation('実行しますか？ (y/n): ');
+  if (!confirmed) {
+    console.log('キャンセルしました。');
+    process.exit(0);
+  }
+
+  // 5. Execute renames
+  for (const r of renames) {
+    fs.renameSync(r.from, r.to);
+    console.log(`✅ ${r.fromName} -> ${r.toName}`);
+  }
+
+  console.log(`\n次のステップ: node scripts/convertTranscript.js ${episodeNum}`);
+}
+
+main().catch(console.error);

--- a/scripts/renameDownloads.js
+++ b/scripts/renameDownloads.js
@@ -22,8 +22,13 @@ function parseArgs(argv) {
       args.autoApprove = true;
     } else if (arg === '--json') {
       args.json = true;
-    } else if (!args.episodeNum) {
-      args.episodeNum = parseInt(arg, 10);
+    } else if (args.episodeNum === null) {
+      const parsed = parseInt(arg, 10);
+      if (!Number.isFinite(parsed)) {
+        console.error('エピソード番号が不正です:', arg);
+        process.exit(1);
+      }
+      args.episodeNum = parsed;
     }
   }
 
@@ -33,16 +38,29 @@ function parseArgs(argv) {
 function fetchNextEpisodeNumber() {
   return new Promise((resolve, reject) => {
     https.get(RSS_URL, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        reject(new Error(`HTTP ${res.statusCode} from ${RSS_URL}`));
+        return;
+      }
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {
         const parser = new xml2js.Parser();
         parser.parseString(data, (err, result) => {
           if (err) return reject(err);
-          const items = result.rss.channel[0].item;
-          resolve(items.length + 1);
+          try {
+            const items = result?.rss?.channel?.[0]?.item;
+            if (!Array.isArray(items)) {
+              return reject(new Error('RSS response missing channel.item'));
+            }
+            resolve(items.length + 1);
+          } catch (e) {
+            reject(e);
+          }
         });
       });
+      res.on('error', reject);
     }).on('error', reject);
   });
 }
@@ -54,16 +72,15 @@ function findCandidateFiles() {
 
   for (const ext of EXTENSIONS) {
     const matching = allFiles
-      .filter((f) => {
-        if (!f.endsWith(ext)) return false;
-        if (f.startsWith('momitfm')) return false;
+      .reduce((acc, f) => {
+        if (!f.endsWith(ext)) return acc;
+        if (f.startsWith('momitfm')) return acc;
         const stat = fs.statSync(path.join(DOWNLOADS_DIR, f));
-        return stat.isFile() && stat.mtimeMs >= cutoff;
-      })
-      .map((f) => {
-        const stat = fs.statSync(path.join(DOWNLOADS_DIR, f));
-        return { name: f, mtime: stat.mtimeMs };
-      })
+        if (stat.isFile() && stat.mtimeMs >= cutoff) {
+          acc.push({ name: f, mtime: stat.mtimeMs });
+        }
+        return acc;
+      }, [])
       .sort((a, b) => b.mtime - a.mtime);
 
     if (matching.length > 0) {
@@ -88,12 +105,8 @@ async function main() {
   // 1. Determine episode number
   let episodeNum;
   const args = parseArgs(process.argv);
-  if (args.episodeNum) {
+  if (args.episodeNum !== null) {
     episodeNum = args.episodeNum;
-    if (isNaN(episodeNum)) {
-      console.error('エピソード番号が不正です:', process.argv[2]);
-      process.exit(1);
-    }
   } else {
     try {
       episodeNum = await fetchNextEpisodeNumber();
@@ -108,7 +121,11 @@ async function main() {
   // 2. Find candidate files
   const candidates = findCandidateFiles();
   if (candidates.size === 0) {
-    console.log(`~/Downloads に過去 ${RECENCY_DAYS} 日以内の対象ファイル (.txt, .srt, .mp3) が見つかりませんでした。`);
+    if (args.json) {
+      process.stdout.write(JSON.stringify({ episodeNum, renames: [] }, null, 2) + '\n');
+    } else {
+      console.log(`~/Downloads に過去 ${RECENCY_DAYS} 日以内の対象ファイル (.txt, .srt, .mp3) が見つかりませんでした。`);
+    }
     process.exit(0);
   }
 
@@ -118,7 +135,7 @@ async function main() {
     const target = `momitfm${episodeNum}${ext}`;
     const targetPath = path.join(DOWNLOADS_DIR, target);
     if (fs.existsSync(targetPath)) {
-      console.log(`⚠️  スキップ: ${target} は既に存在します`);
+      if (!args.json) console.log(`⚠️  スキップ: ${target} は既に存在します`);
       continue;
     }
     renames.push({
@@ -130,41 +147,44 @@ async function main() {
   }
 
   if (renames.length === 0) {
-    console.log('リネーム対象のファイルがありません。');
+    if (args.json) {
+      process.stdout.write(JSON.stringify({ episodeNum, renames: [] }, null, 2) + '\n');
+    } else {
+      console.log('リネーム対象のファイルがありません。');
+    }
     process.exit(0);
   }
 
   if (args.json) {
-    console.log(JSON.stringify({
-      episodeNum,
-      renames
-    }, null, 2));
+    process.stdout.write(JSON.stringify({ episodeNum, renames }, null, 2) + '\n');
     if (!args.autoApprove) {
       process.exit(0);
     }
+  } else {
+    // 4. Show plan and confirm (human-readable only when not in JSON mode)
+    console.log(`\nEpisode ${episodeNum} のファイルをリネームします:\n`);
+    const maxFromLen = Math.max(...renames.map((r) => r.fromName.length));
+    for (const r of renames) {
+      console.log(`  ${r.fromName.padEnd(maxFromLen)}  ->  ${r.toName}`);
+    }
+    console.log();
   }
-
-  // 4. Show plan and confirm
-  console.log(`\nEpisode ${episodeNum} のファイルをリネームします:\n`);
-  const maxFromLen = Math.max(...renames.map((r) => r.fromName.length));
-  for (const r of renames) {
-    console.log(`  ${r.fromName.padEnd(maxFromLen)}  ->  ${r.toName}`);
-  }
-  console.log();
 
   const confirmed = args.autoApprove ? true : await askConfirmation('実行しますか？ (y/n): ');
   if (!confirmed) {
-    console.log('キャンセルしました。');
+    if (!args.json) console.log('キャンセルしました。');
     process.exit(0);
   }
 
   // 5. Execute renames
   for (const r of renames) {
     fs.renameSync(r.from, r.to);
-    console.log(`✅ ${r.fromName} -> ${r.toName}`);
+    if (!args.json) console.log(`✅ ${r.fromName} -> ${r.toName}`);
   }
 
-  console.log(`\n次のステップ: node scripts/convertTranscript.js ${episodeNum}`);
+  if (!args.json) {
+    console.log(`\n次のステップ: node scripts/convertTranscript.js ${episodeNum}`);
+  }
 }
 
 main().catch(console.error);

--- a/scripts/transcriptUtils.js
+++ b/scripts/transcriptUtils.js
@@ -1,0 +1,67 @@
+const SPEAKER_LINE_RE = /^(.+?)\s*\((\d{1,2}:\d{2}\.\d{2,3})\)$/;
+
+function formatTimestamp(timestamp) {
+  const [minSec] = timestamp.split('.');
+  const parts = minSec.split(':');
+
+  if (parts.length === 2) {
+    const [min, sec] = parts;
+    return `00:${min.padStart(2, '0')}:${sec.padStart(2, '0')}`;
+  } else if (parts.length === 3) {
+    return parts.map((part) => part.padStart(2, '0')).join(':');
+  }
+
+  return timestamp;
+}
+
+function parseTranscriptText(text, episodeId) {
+  const lines = text.split('\n');
+  const segments = [];
+
+  let currentSpeaker = '';
+  let currentTimestamp = '';
+  let currentText = '';
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const speakerMatch = trimmed.match(SPEAKER_LINE_RE);
+
+    if (speakerMatch) {
+      if (currentSpeaker && currentText) {
+        segments.push({
+          speaker: currentSpeaker,
+          timestamp: formatTimestamp(currentTimestamp),
+          text: currentText.trim()
+        });
+      }
+
+      currentSpeaker = speakerMatch[1];
+      currentTimestamp = speakerMatch[2];
+      currentText = '';
+    } else {
+      const cleanedText = trimmed.replace(/\s+/g, '');
+      currentText += cleanedText;
+    }
+  }
+
+  if (currentSpeaker && currentText) {
+    segments.push({
+      speaker: currentSpeaker,
+      timestamp: formatTimestamp(currentTimestamp),
+      text: currentText.trim()
+    });
+  }
+
+  return {
+    episodeId,
+    segments
+  };
+}
+
+module.exports = {
+  formatTimestamp,
+  parseTranscriptText
+};
+

--- a/scripts/validateTranscript.js
+++ b/scripts/validateTranscript.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+const TIMESTAMP_RE = /^\d{2}:\d{2}:\d{2}$/;
+
+function validateTranscript(filePath) {
+  const payload = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  const problems = [];
+
+  if (!Number.isInteger(payload.episodeId)) {
+    problems.push('episodeId must be an integer');
+  }
+
+  if (!Array.isArray(payload.segments) || payload.segments.length === 0) {
+    problems.push('segments must be a non-empty array');
+  } else {
+    payload.segments.forEach((segment, index) => {
+      if (typeof segment.speaker !== 'string' || !segment.speaker.trim()) {
+        problems.push(`segments[${index}].speaker must be a non-empty string`);
+      }
+      if (typeof segment.timestamp !== 'string' || !TIMESTAMP_RE.test(segment.timestamp)) {
+        problems.push(`segments[${index}].timestamp must match HH:MM:SS`);
+      }
+      if (typeof segment.text !== 'string' || !segment.text.trim()) {
+        problems.push(`segments[${index}].text must be a non-empty string`);
+      }
+    });
+  }
+
+  return problems;
+}
+
+function main() {
+  const targets = process.argv.slice(2);
+  const files = targets.length > 0
+    ? targets
+    : fs.readdirSync(path.join(process.cwd(), 'public', 'transcripts'))
+      .filter((file) => file.endsWith('.json'))
+      .map((file) => path.join(process.cwd(), 'public', 'transcripts', file));
+
+  const failures = [];
+
+  files.forEach((filePath) => {
+    const problems = validateTranscript(filePath);
+    if (problems.length === 0) {
+      console.log(`✅ ${filePath}`);
+      return;
+    }
+
+    failures.push({ filePath, problems });
+    console.error(`❌ ${filePath}`);
+    problems.forEach((problem) => console.error(`   - ${problem}`));
+  });
+
+  if (failures.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add transcript intake helpers: `scripts/renameDownloads.js`, `scripts/validateTranscript.js`, `scripts/transcriptUtils.js`, plus a `.claude/hooks/check-riverside-downloads.sh` hook
- Refactor `scripts/convertTranscript.js` to use the shared `transcriptUtils` helpers
- Add `AGENTS.md` with repository guidelines for AI agents
- Document the new `renameDownloads.js` workflow in `CLAUDE.md`

## Test plan
- [ ] `node scripts/renameDownloads.js` against sample Riverside downloads in ~/Downloads
- [ ] `node scripts/validateTranscript.js <N>` against an existing transcript
- [ ] `node scripts/convertTranscript.js <N>` still produces the expected JSON output
- [ ] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)