### PR TITLE
[codex] Add static episode pagination

### DIFF
--- a/components/EpisodeArchive.tsx
+++ b/components/EpisodeArchive.tsx
@@ -10,11 +10,41 @@ type EpisodeArchiveProps = {
   totalPages: number;
 };
 
+function getVisiblePages(currentPage: number, totalPages: number): number[] {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const visiblePages = new Set([
+    1,
+    totalPages,
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+  ]);
+
+  if (currentPage <= 3) {
+    visiblePages.add(2);
+    visiblePages.add(3);
+  }
+
+  if (currentPage >= totalPages - 2) {
+    visiblePages.add(totalPages - 2);
+    visiblePages.add(totalPages - 1);
+  }
+
+  return Array.from(visiblePages)
+    .filter((page) => page >= 1 && page <= totalPages)
+    .sort((a, b) => a - b);
+}
+
 export default function EpisodeArchive({
   episodes,
   currentPage,
   totalPages,
 }: EpisodeArchiveProps) {
+  const visiblePages = getVisiblePages(currentPage, totalPages);
+
   return (
     <main className={styles.main}>
       {episodes.map((item) => (
@@ -28,25 +58,99 @@ export default function EpisodeArchive({
       {totalPages > 1 && (
         <nav
           className={styles.pagination}
-          aria-label="Episode archive pagination"
+          aria-labelledby="episode-pagination-title"
         >
+          <div className={styles.pagination_header}>
+            <h2
+              className={styles.pagination_title}
+              id="episode-pagination-title"
+            >
+              Archive navigation
+            </h2>
+            <p className={styles.pagination_status}>
+              Page {currentPage} of {totalPages}
+            </p>
+          </div>
+          <div className={styles.pagination_controls}>
+            {currentPage > 1 ? (
+              <Link
+                className={styles.pagination_button}
+                href={getPageHref(currentPage - 1)}
+              >
+                <span aria-hidden="true">←</span>
+                <span>Newer episodes</span>
+                <span className={styles.pagination_button_page}>
+                  Page {currentPage - 1}
+                </span>
+              </Link>
+            ) : (
+              <span
+                className={`${styles.pagination_button} ${styles.pagination_button_disabled}`}
+                aria-disabled="true"
+              >
+                <span aria-hidden="true">←</span>
+                <span>Newer episodes</span>
+              </span>
+            )}
+            <div className={styles.pagination_pages} aria-label="Archive pages">
+              {visiblePages.map((page, index) => {
+                const previousPage = visiblePages[index - 1];
+                const showGap = previousPage && page - previousPage > 1;
+
+                return (
+                  <span className={styles.pagination_page_group} key={page}>
+                    {showGap && (
+                      <span
+                        className={styles.pagination_ellipsis}
+                        aria-hidden="true"
+                      >
+                        ...
+                      </span>
+                    )}
+                    {page === currentPage ? (
+                      <span
+                        className={`${styles.pagination_page} ${styles.pagination_page_current}`}
+                        aria-current="page"
+                      >
+                        {page}
+                      </span>
+                    ) : (
+                      <Link
+                        className={styles.pagination_page}
+                        href={getPageHref(page)}
+                        aria-label={`Go to archive page ${page}`}
+                      >
+                        {page}
+                      </Link>
+                    )}
+                  </span>
+                );
+              })}
+            </div>
+            {currentPage < totalPages ? (
+              <Link
+                className={styles.pagination_button}
+                href={getPageHref(currentPage + 1)}
+              >
+                <span>Older episodes</span>
+                <span className={styles.pagination_button_page}>
+                  Page {currentPage + 1}
+                </span>
+                <span aria-hidden="true">→</span>
+              </Link>
+            ) : (
+              <span
+                className={`${styles.pagination_button} ${styles.pagination_button_disabled}`}
+                aria-disabled="true"
+              >
+                <span>Older episodes</span>
+                <span aria-hidden="true">→</span>
+              </span>
+            )}
+          </div>
           {currentPage > 1 && (
-            <Link
-              className={styles.pagination_link}
-              href={getPageHref(currentPage - 1)}
-            >
-              Newer episodes
-            </Link>
-          )}
-          <span className={styles.pagination_status}>
-            Page {currentPage} of {totalPages}
-          </span>
-          {currentPage < totalPages && (
-            <Link
-              className={styles.pagination_link}
-              href={getPageHref(currentPage + 1)}
-            >
-              Older episodes
+            <Link className={styles.pagination_latest} href="/">
+              Back to latest episodes
             </Link>
           )}
         </nav>

--- a/components/EpisodeArchive.tsx
+++ b/components/EpisodeArchive.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import type { EpisodeSummary } from "../util/rss";
+import { getPageHref } from "../util/rss";
+import { formatDate } from "../util";
+import styles from "../styles/Home.module.css";
+
+type EpisodeArchiveProps = {
+  episodes: EpisodeSummary[];
+  currentPage: number;
+  totalPages: number;
+};
+
+export default function EpisodeArchive({
+  episodes,
+  currentPage,
+  totalPages,
+}: EpisodeArchiveProps) {
+  return (
+    <main className={styles.main}>
+      {episodes.map((item) => (
+        <article key={`ep-${item.id}`}>
+          <h2 className={styles.main_title}>
+            <Link href={`/episode/${item.id}`}>{item.title[0]}</Link>
+          </h2>
+          <p className={styles.main_date}>{formatDate(item.pubDate)}</p>
+        </article>
+      ))}
+      {totalPages > 1 && (
+        <nav
+          className={styles.pagination}
+          aria-label="Episode archive pagination"
+        >
+          {currentPage > 1 && (
+            <Link
+              className={styles.pagination_link}
+              href={getPageHref(currentPage - 1)}
+            >
+              Newer episodes
+            </Link>
+          )}
+          <span className={styles.pagination_status}>
+            Page {currentPage} of {totalPages}
+          </span>
+          {currentPage < totalPages && (
+            <Link
+              className={styles.pagination_link}
+              href={getPageHref(currentPage + 1)}
+            >
+              Older episodes
+            </Link>
+          )}
+        </nav>
+      )}
+    </main>
+  );
+}

--- a/pages/episode/[id].tsx
+++ b/pages/episode/[id].tsx
@@ -1,31 +1,20 @@
-import xml2js from "xml2js";
 import { useRef } from "react";
 import Footer from "../../components/Footer";
 import Head from "../../components/Head";
 import Header from "../../components/Header";
 import Transcript from "../../components/Transcript";
-import { rssUrl } from "../../const";
-import styles from '../../styles/Home.module.css'
+import styles from "../../styles/Home.module.css";
 import { formatDate } from "../../util";
+import { fetchEpisodes, getEpisodeById } from "../../util/rss";
 import fs from "fs";
 import path from "path";
 
 export async function getStaticPaths() {
-    const res = await fetch(rssUrl);
-    const text = await res.text()
-    let parser = new xml2js.Parser();
-    let item = [];
-    parser.parseString(text, (err: any, r: { rss: { channel: { item: any[]; }[]; }; }) => {
-        if (err) {
-            console.error(err);
-            return;
-        }
-        item = r.rss.channel[0].item;
-    })
-
-    let paths: main.RSS["paths"] = item.map((e, i: number) => {
-        return { params: { id: (i + 1).toString() } }
+    const episodes = await fetchEpisodes();
+    const paths = episodes.map((episode) => {
+        return { params: { id: episode.id.toString() } }
     });
+
     return {
         paths,
         fallback: false
@@ -33,9 +22,15 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
-    const items: main.RSS["item"][] = await fetchRSS()
-    const id: number = params["id"]
-    const item: main.RSS["item"] = items.reverse()[id - 1]
+    const episodes = await fetchEpisodes();
+    const id = Number(params["id"]);
+    const item = getEpisodeById(episodes, id);
+
+    if (!item) {
+        return {
+            notFound: true
+        };
+    }
 
     // Try to load transcript if it exists
     let transcript: main.Transcript | null = null;
@@ -55,21 +50,6 @@ export async function getStaticProps({ params }) {
             transcript
         }
     };
-}
-
-async function fetchRSS() {
-    const res = await fetch(rssUrl);
-    const text = await res.text()
-    let parser = new xml2js.Parser();
-    let item
-    parser.parseString(text, (err, r) => {
-        if (err) {
-            console.error(err);
-            return;
-        }
-        item = r.rss.channel[0].item;
-    })
-    return item;
 }
 
 export default function Episode({ item, transcript }) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,69 +1,41 @@
-import Image from "next/image";
-import Link from "next/link";
-import styles from "../styles/Home.module.css";
-import xml2js from "xml2js";
-import { rssUrl, siteDescription } from "../const";
+import { siteDescription } from "../const";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import Head from "../components/Head";
-import { formatDate } from "../util";
-import { ReactNode } from "react";
+import EpisodeArchive from "../components/EpisodeArchive";
+import {
+  fetchEpisodes,
+  getEpisodeSummariesForPage,
+  getTotalPages,
+  type EpisodeSummary,
+} from "../util/rss";
+
+type HomeProps = {
+  episodes: EpisodeSummary[];
+  totalPages: number;
+};
 
 export async function getStaticProps() {
-  const res = await fetch(rssUrl);
-  const text = await res.text();
-  let parser = new xml2js.Parser();
+  const episodes = await fetchEpisodes();
 
-  let item = [];
-  parser.parseString(
-    text,
-    (err: any, r: { rss: { channel: { item: any[] }[] } }) => {
-      if (err) {
-        console.error(err);
-        return;
-      }
-      item = r.rss.channel[0].item;
-    }
-  );
   return {
     props: {
-      item,
+      episodes: getEpisodeSummariesForPage(episodes, 1),
+      totalPages: getTotalPages(episodes.length),
     },
   };
 }
 
-export default function Home(items: main.RSS["item"]) {
-  const episodes = items["item"];
-  let id = episodes.length + 1;
-
+export default function Home({ episodes, totalPages }: HomeProps) {
   return (
-    <div className={styles.container}>
+    <div>
       <Head title="momit.fm" description={siteDescription}></Head>
       <Header></Header>
-      <div className={styles.main}>
-        {episodes.map(
-          (
-            item: {
-              [x: string]: any;
-              title: ReactNode[];
-              pubDate: string;
-            },
-            index: number
-          ) => {
-            id = id - 1;
-
-            return (
-              <article key={`ep-${id}`}>
-                <h2 className={styles.main_title}>
-                  <Link href={`/episode/${id}`}>{item.title[0]}</Link>
-                </h2>
-                <p className={styles.main_date}>{formatDate(item.pubDate)}</p>
-                {/* <div className={styles.main_description} dangerouslySetInnerHTML={{ __html: item["description"][0] }}></div> */}
-              </article>
-            );
-          }
-        )}
-      </div>
+      <EpisodeArchive
+        episodes={episodes}
+        currentPage={1}
+        totalPages={totalPages}
+      />
       <Footer></Footer>
     </div>
   );

--- a/pages/page/[page].tsx
+++ b/pages/page/[page].tsx
@@ -35,16 +35,6 @@ export async function getStaticProps({ params }) {
   const episodes = await fetchEpisodes();
   const totalPages = getTotalPages(episodes.length);
 
-  if (
-    !Number.isInteger(currentPage) ||
-    currentPage < 2 ||
-    currentPage > totalPages
-  ) {
-    return {
-      notFound: true,
-    };
-  }
-
   return {
     props: {
       episodes: getEpisodeSummariesForPage(episodes, currentPage),

--- a/pages/page/[page].tsx
+++ b/pages/page/[page].tsx
@@ -1,0 +1,77 @@
+import Footer from "../../components/Footer";
+import Head from "../../components/Head";
+import Header from "../../components/Header";
+import EpisodeArchive from "../../components/EpisodeArchive";
+import { siteDescription } from "../../const";
+import {
+  fetchEpisodes,
+  getEpisodeSummariesForPage,
+  getTotalPages,
+  type EpisodeSummary,
+} from "../../util/rss";
+
+type EpisodePageProps = {
+  episodes: EpisodeSummary[];
+  currentPage: number;
+  totalPages: number;
+};
+
+export async function getStaticPaths() {
+  const episodes = await fetchEpisodes();
+  const totalPages = getTotalPages(episodes.length);
+  const paths = Array.from({ length: Math.max(totalPages - 1, 0) }, (_, i) => {
+    const page = i + 2;
+    return { params: { page: page.toString() } };
+  });
+
+  return {
+    paths,
+    fallback: false,
+  };
+}
+
+export async function getStaticProps({ params }) {
+  const currentPage = Number(params["page"]);
+  const episodes = await fetchEpisodes();
+  const totalPages = getTotalPages(episodes.length);
+
+  if (
+    !Number.isInteger(currentPage) ||
+    currentPage < 2 ||
+    currentPage > totalPages
+  ) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      episodes: getEpisodeSummariesForPage(episodes, currentPage),
+      currentPage,
+      totalPages,
+    },
+  };
+}
+
+export default function EpisodePage({
+  episodes,
+  currentPage,
+  totalPages,
+}: EpisodePageProps) {
+  return (
+    <div>
+      <Head
+        title={`momit.fm - Page ${currentPage}`}
+        description={siteDescription}
+      ></Head>
+      <Header></Header>
+      <EpisodeArchive
+        episodes={episodes}
+        currentPage={currentPage}
+        totalPages={totalPages}
+      />
+      <Footer></Footer>
+    </div>
+  );
+}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -60,29 +60,123 @@
 }
 
 .pagination {
-  align-items: center;
   border-top: 1px solid #eaeaea;
-  display: flex;
-  flex-wrap: wrap;
+  color: #2f3437;
+  display: grid;
   gap: 1rem;
-  justify-content: center;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
   padding-top: 2rem;
 }
 
-.pagination_link {
-  border: 1px solid #635f5a;
-  border-radius: 4px;
-  padding: 0.5rem 0.75rem;
-  text-decoration: none;
+.pagination_header {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
 }
 
-.main .pagination_link {
-  text-decoration: none;
+.pagination_title {
+  font-size: 1.1rem;
+  margin: 0;
 }
 
 .pagination_status {
   color: #635f5a;
+  margin: 0;
+}
+
+.pagination_controls {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.pagination_button {
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #635f5a;
+  border-radius: 4px;
+  color: #2f3437;
+  display: inline-flex;
+  gap: 0.5rem;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.6rem 0.85rem;
+  text-decoration: none;
+}
+
+.main .pagination_button,
+.main .pagination_page,
+.main .pagination_latest {
+  text-decoration: none;
+}
+
+.pagination_button:hover,
+.pagination_page:hover,
+.pagination_latest:hover {
+  background-color: #f4f4f0;
+}
+
+.pagination_button_disabled {
+  background-color: transparent;
+  border-color: #d4d1ca;
+  color: #8f8b86;
+  cursor: default;
+}
+
+.pagination_button_disabled:hover {
+  background-color: transparent;
+}
+
+.pagination_button_page {
+  color: #635f5a;
+  font-size: 0.85rem;
+}
+
+.pagination_pages {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  justify-content: center;
+}
+
+.pagination_page_group {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.pagination_page {
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #d4d1ca;
+  border-radius: 4px;
+  color: #2f3437;
+  display: inline-flex;
+  height: 40px;
+  justify-content: center;
+  min-width: 40px;
+  padding: 0 0.6rem;
+}
+
+.pagination_page_current {
+  background-color: #2f3437;
+  border-color: #2f3437;
+  color: white;
+}
+
+.pagination_ellipsis {
+  color: #635f5a;
+  padding: 0 0.2rem;
+}
+
+.pagination_latest {
+  color: #635f5a;
+  justify-self: center;
+  padding: 0.35rem 0.5rem;
 }
 
 .main_audio {
@@ -149,6 +243,12 @@
 @media (max-width: 600px) {
   .main {
     margin: 1rem 2rem;
+  }
+  .pagination_controls {
+    grid-template-columns: 1fr;
+  }
+  .pagination_button {
+    width: 100%;
   }
   .footer_inner {
     flex-direction: column;

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -59,6 +59,32 @@
   margin-top: 0;
 }
 
+.pagination {
+  align-items: center;
+  border-top: 1px solid #eaeaea;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+  padding-top: 2rem;
+}
+
+.pagination_link {
+  border: 1px solid #635f5a;
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+}
+
+.main .pagination_link {
+  text-decoration: none;
+}
+
+.pagination_status {
+  color: #635f5a;
+}
+
 .main_audio {
   width: 100%;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,7 @@
 html,
 body {
+  background-color: #fff;
+  color: #111;
   padding: 0;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,

--- a/util/rss.ts
+++ b/util/rss.ts
@@ -25,7 +25,9 @@ type ParsedRss = {
   };
 };
 
-export async function fetchEpisodes(): Promise<Episode[]> {
+let episodesCache: Promise<Episode[]> | null = null;
+
+async function fetchEpisodesFromRss(): Promise<Episode[]> {
   const res = await fetch(rssUrl);
 
   if (!res.ok) {
@@ -43,14 +45,22 @@ export async function fetchEpisodes(): Promise<Episode[]> {
   }));
 }
 
+export async function fetchEpisodes(): Promise<Episode[]> {
+  if (!episodesCache) {
+    episodesCache = fetchEpisodesFromRss().catch((error) => {
+      episodesCache = null;
+      throw error;
+    });
+  }
+
+  return episodesCache;
+}
+
 export function getTotalPages(episodeCount: number): number {
   return Math.max(1, Math.ceil(episodeCount / EPISODES_PER_PAGE));
 }
 
-export function getEpisodesForPage(
-  episodes: Episode[],
-  page: number
-): Episode[] {
+function getEpisodesForPage(episodes: Episode[], page: number): Episode[] {
   const start = (page - 1) * EPISODES_PER_PAGE;
   return episodes.slice(start, start + EPISODES_PER_PAGE);
 }

--- a/util/rss.ts
+++ b/util/rss.ts
@@ -1,0 +1,78 @@
+import { parseStringPromise } from "xml2js";
+import { rssUrl } from "../const";
+
+export const EPISODES_PER_PAGE = 50;
+
+export type RssEpisode = {
+  title: string[];
+  description: string[];
+  pubDate: string;
+  enclosure: { $: { url: string } }[];
+  [key: string]: any;
+};
+
+export type Episode = RssEpisode & {
+  id: number;
+};
+
+export type EpisodeSummary = Pick<Episode, "id" | "title" | "pubDate">;
+
+type ParsedRss = {
+  rss?: {
+    channel?: {
+      item?: RssEpisode[];
+    }[];
+  };
+};
+
+export async function fetchEpisodes(): Promise<Episode[]> {
+  const res = await fetch(rssUrl);
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch RSS feed: ${res.status}`);
+  }
+
+  const text = await res.text();
+  const parsed: ParsedRss = await parseStringPromise(text);
+  const items = parsed.rss?.channel?.[0]?.item ?? [];
+  const episodeCount = items.length;
+
+  return items.map((item, index) => ({
+    ...item,
+    id: episodeCount - index,
+  }));
+}
+
+export function getTotalPages(episodeCount: number): number {
+  return Math.max(1, Math.ceil(episodeCount / EPISODES_PER_PAGE));
+}
+
+export function getEpisodesForPage(
+  episodes: Episode[],
+  page: number
+): Episode[] {
+  const start = (page - 1) * EPISODES_PER_PAGE;
+  return episodes.slice(start, start + EPISODES_PER_PAGE);
+}
+
+export function getEpisodeSummariesForPage(
+  episodes: Episode[],
+  page: number
+): EpisodeSummary[] {
+  return getEpisodesForPage(episodes, page).map(({ id, title, pubDate }) => ({
+    id,
+    title,
+    pubDate,
+  }));
+}
+
+export function getEpisodeById(
+  episodes: Episode[],
+  id: number
+): Episode | undefined {
+  return episodes.find((episode) => episode.id === id);
+}
+
+export function getPageHref(page: number): string {
+  return page === 1 ? "/" : `/page/${page}`;
+}


### PR DESCRIPTION
## Summary
- Add shared RSS helpers for episode ID assignment, page slicing, and page URL generation.
- Render the homepage as page 1 with 50 newest episodes.
- Add static `/page/[page]` archive pages for older episodes with newer/older navigation.
- Reuse the shared RSS helper on episode detail pages so episode IDs stay consistent.

## Validation
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm run build` passed with RSS network access.
- Browser smoke test passed for `/`, `/page/2`, and `/episode/97`.
- `npm run lint` is currently blocked by the repo's existing `eslint@10.4.0` incompatibility with `eslint-config-next` React plugin dependencies.